### PR TITLE
tscfg-maven-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ project/plugins/project/
 .worksheet
 
 # Created by .ignore support plugin (hsz.mobi)
+
+# IntelliJ
+.idea
+*.iml
+maven-plugin/.idea/
+maven-plugin/*.iml

--- a/maven-plugin/README.md
+++ b/maven-plugin/README.md
@@ -1,0 +1,23 @@
+# tscfg-maven-plugin
+
+Maven plugin to generate config class file based on template file using tscfg.
+
+## Usage
+```xml
+<plugin>
+    <groupId>com.sentiance</groupId>
+    <artifactId>tscfg-maven-plugin</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <configuration>
+        <templateFile>config-spec/aligner.spec.conf</templateFile>
+        <packageName>com.sentiance.service.aligner.config</packageName>
+        <className>AlignerConfig</className>
+    </configuration>
+</plugin>
+```
+
+## Configuration
+* templateFile: typesafe configuration template file
+* className: the name of the generated config class 
+* packageName: the package of the generated config class
+* outputDirectory: the output directory for the generated class, default is `target/generated-sources/tscfg/`

--- a/maven-plugin/README.md
+++ b/maven-plugin/README.md
@@ -5,9 +5,9 @@ Maven plugin to generate config class file based on template file using tscfg.
 ## Usage
 ```xml
 <plugin>
-    <groupId>com.sentiance</groupId>
+    <groupId>com.github.carueda</groupId>
     <artifactId>tscfg-maven-plugin</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0</version>
     <configuration>
         <templateFile>config-spec/aligner.spec.conf</templateFile>
         <packageName>com.sentiance.service.aligner.config</packageName>

--- a/maven-plugin/README.md
+++ b/maven-plugin/README.md
@@ -13,6 +13,14 @@ Maven plugin to generate config class file based on template file using tscfg.
         <packageName>com.sentiance.service.aligner.config</packageName>
         <className>AlignerConfig</className>
     </configuration>
+     <executions>
+        <execution>
+            <id>tscfg-sources</id>
+            <goals>
+                <goal>generate-config-class</goal>
+            </goals>
+        </execution>
+    </executions>
 </plugin>
 ```
 

--- a/maven-plugin/README.md
+++ b/maven-plugin/README.md
@@ -32,4 +32,4 @@ Maven plugin to generate config class file based on template file using tscfg.
 
 ## Current limitations
 * Currently only Java class generated is supported. It should be easy to extend this plugin to generate Scala files.
-* This plugin always generates java classes for Java 7 and above. This should also be easy to extend.   
+* This plugin always generates java classes for Java 8 and above. This should also be easy to extend.   

--- a/maven-plugin/README.md
+++ b/maven-plugin/README.md
@@ -29,3 +29,7 @@ Maven plugin to generate config class file based on template file using tscfg.
 * className: the name of the generated config class 
 * packageName: the package of the generated config class
 * outputDirectory: the output directory for the generated class, default is `target/generated-sources/tscfg/`
+
+## Current limitations
+* Currently only Java class generated is supported. It should be easy to extend this plugin to generate Scala files.
+* This plugin always generates java classes for Java 7 and above. This should also be easy to extend.   

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -1,9 +1,9 @@
 <project>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.sentiance</groupId>
+    <groupId>com.github.carueda</groupId>
     <artifactId>tscfg-maven-plugin</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <build>
         <plugins>
             <plugin>
@@ -27,9 +27,7 @@
     <developers>
         <developer>
             <name>Tim Van Laer</name>
-            <email>tim.vanlaer@sentiance.com</email>
-            <organization>Sentiance</organization>
-            <organizationUrl>https://sentiance.com</organizationUrl>
+            <email>timvanlaer@gmail.com</email>
         </developer>
     </developers>
 
@@ -92,17 +90,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>sentiance.repo</id>
-            <name>Sentiance Repository</name>
-            <url>http://ec2-52-210-185-85.eu-west-1.compute.amazonaws.com:8081/artifactory/libs-snapshot-local</url>
-        </snapshotRepository>
-        <repository>
-            <id>sentiance.repo</id>
-            <name>Sentiance Repository</name>
-            <url>http://ec2-52-210-185-85.eu-west-1.compute.amazonaws.com:8081/artifactory/libs-release-local</url>
-        </repository>
-    </distributionManagement>
 </project>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -1,0 +1,64 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.sentiance</groupId>
+    <artifactId>tscfg-maven-plugin</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <packaging>maven-plugin</packaging>
+
+    <name>tscfg Maven Plugin</name>
+
+    <developers>
+        <developer>
+            <name>Tim Van Laer</name>
+            <email>tim.vanlaer@sentiance.com</email>
+            <organization>Sentiance</organization>
+            <organizationUrl>https://sentiance.com</organizationUrl>
+        </developer>
+    </developers>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.5.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>2.2.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.carueda</groupId>
+            <artifactId>tscfg_2.11</artifactId>
+            <version>0.8.3</version>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -4,32 +4,30 @@
     <groupId>com.github.carueda</groupId>
     <artifactId>tscfg-maven-plugin</artifactId>
     <version>0.2.0</version>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
     <packaging>maven-plugin</packaging>
 
     <name>tscfg Maven Plugin</name>
 
     <developers>
         <developer>
+            <id>timvlaer</id>
             <name>Tim Van Laer</name>
             <email>timvanlaer@gmail.com</email>
         </developer>
     </developers>
+
+    <licenses>
+        <license>
+            <name>Apache 2.0</name>
+            <url>http://www.opensource.org/licenses/Apache-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git@github.com:carueda/tscfg.git</connection>
+        <url>http://github.com/carueda/tscfg</url>
+    </scm>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -90,4 +88,32 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -39,19 +39,19 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>3.5.0</version>
+            <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.5</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-project</artifactId>
             <version>2.2.1</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -59,6 +59,18 @@
             <artifactId>tscfg_2.11</artifactId>
             <version>0.8.3</version>
         </dependency>
-
     </dependencies>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sentiance.repo</id>
+            <name>Sentiance Repository</name>
+            <url>http://ec2-52-210-185-85.eu-west-1.compute.amazonaws.com:8081/artifactory/libs-snapshot-local</url>
+        </snapshotRepository>
+        <repository>
+            <id>sentiance.repo</id>
+            <name>Sentiance Repository</name>
+            <url>http://ec2-52-210-185-85.eu-west-1.compute.amazonaws.com:8081/artifactory/libs-release-local</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -3,16 +3,20 @@
 
     <groupId>com.sentiance</groupId>
     <artifactId>tscfg-maven-plugin</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0</version>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -32,13 +36,15 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+
+        <maven.version>3.3.9</maven.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.5.0</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -58,6 +64,32 @@
             <groupId>com.github.carueda</groupId>
             <artifactId>tscfg_2.11</artifactId>
             <version>0.8.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.8.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/maven-plugin/src/main/java/tscfg/GeneratorMojo.java
+++ b/maven-plugin/src/main/java/tscfg/GeneratorMojo.java
@@ -1,0 +1,82 @@
+package tscfg;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import tscfg.generators.GenOpts;
+import tscfg.generators.GenResult;
+import tscfg.generators.Generator;
+import tscfg.generators.java.JavaGen;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+@Mojo(name = "generate-config-class", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+public class GeneratorMojo extends AbstractMojo {
+
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  @Parameter(required = true)
+  private File templateFile;
+
+  @Parameter(required = true)
+  private String packageName;
+
+  @Parameter(required = true)
+  private String className;
+
+  @Parameter(defaultValue = "target/generated-sources/tscfg/")
+  private String outputDirectory;
+
+  @Parameter(defaultValue = "${project}", required = true, readonly = true)
+  private MavenProject project;
+
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    String template = readTemplateFile();
+
+    Generator generator = new JavaGen(new GenOpts(packageName, className, false));
+    GenResult result = generator.generate(ModelBuilder.apply(template).objectType());
+
+    writeResultToJavaFile(result);
+  }
+
+  private String readTemplateFile() throws MojoExecutionException {
+    try {
+      return new String(Files.readAllBytes(templateFile.toPath()), UTF_8);
+    } catch (IOException e) {
+      throw new MojoExecutionException("Failed to read template file: " + e.getMessage());
+    }
+  }
+
+  private void writeResultToJavaFile(GenResult result) throws MojoExecutionException {
+    try {
+      String outputFilePath = outputDirectory + (outputDirectory.endsWith(File.separator) ? "" : File.separator) +
+          packageName.replace(".", File.separator) + File.separator + className + ".java";
+      Path outputFile = new File(project.getModel().getProjectDirectory(), outputFilePath).toPath();
+
+      getLog().debug("Generating config class to " + outputFile);
+
+      mkDirs(outputFile);
+
+      Files.write(outputFile, result.code().getBytes(UTF_8),
+          StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+    } catch (IOException e) {
+      throw new MojoExecutionException("Failed to write file: " + e.getClass() + ": " + e.getMessage());
+    }
+  }
+
+  private void mkDirs(Path outputFile) throws IOException {
+    Path parentDir = outputFile.getParent();
+    if (!Files.exists(parentDir)) {
+      Files.createDirectories(parentDir);
+    }
+  }
+}

--- a/maven-plugin/src/main/java/tscfg/GeneratorMojo.java
+++ b/maven-plugin/src/main/java/tscfg/GeneratorMojo.java
@@ -3,6 +3,7 @@ package tscfg;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -20,6 +21,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
 @Mojo(name = "generate-config-class", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+@Execute(phase = LifecyclePhase.GENERATE_SOURCES, goal = "generate-config-class")
 public class GeneratorMojo extends AbstractMojo {
 
   private static final Charset UTF_8 = Charset.forName("UTF-8");

--- a/maven-plugin/src/main/java/tscfg/TscfgJavaGeneratorMojo.java
+++ b/maven-plugin/src/main/java/tscfg/TscfgJavaGeneratorMojo.java
@@ -18,13 +18,16 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 
 @Mojo(name = "generate-config-class", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 @Execute(phase = LifecyclePhase.GENERATE_SOURCES, goal = "generate-config-class")
-public class GeneratorMojo extends AbstractMojo {
+public class TscfgJavaGeneratorMojo extends AbstractMojo {
 
   private static final Charset UTF_8 = Charset.forName("UTF-8");
+  private static final String PACKAGE_SEPARATOR = ".";
+  private static final String JAVA_FILE_EXTENSION = ".java";
 
   @Parameter(required = true)
   private File templateFile;
@@ -35,22 +38,25 @@ public class GeneratorMojo extends AbstractMojo {
   @Parameter(required = true)
   private String className;
 
-  @Parameter(defaultValue = "target/generated-sources/tscfg/")
+  @Parameter(defaultValue = "${project.build.directory}/generated-sources/tscfg/")
   private String outputDirectory;
 
   @Parameter(defaultValue = "${project}", required = true, readonly = true)
   private MavenProject project;
 
   public void execute() throws MojoExecutionException, MojoFailureException {
-    String template = readTemplateFile();
+    String template = readTscfgTemplate();
 
-    Generator generator = new JavaGen(new GenOpts(packageName, className, false));
-    GenResult result = generator.generate(ModelBuilder.apply(template).objectType());
+    GenResult generatorResult = generateJavaCodeForTemplate(template);
 
-    writeResultToJavaFile(result);
+    Path javaFile = assembleGeneratedJavaFilePath();
+    writeGeneratedCodeToJavaFile(generatorResult.code(), javaFile);
+
+    getLog().debug("Adding " + outputDirectory + " as source root in the maven project.");
+    project.addCompileSourceRoot(outputDirectory);
   }
 
-  private String readTemplateFile() throws MojoExecutionException {
+  private String readTscfgTemplate() throws MojoExecutionException {
     try {
       return new String(Files.readAllBytes(templateFile.toPath()), UTF_8);
     } catch (IOException e) {
@@ -58,24 +64,27 @@ public class GeneratorMojo extends AbstractMojo {
     }
   }
 
-  private void writeResultToJavaFile(GenResult result) throws MojoExecutionException {
+  private GenResult generateJavaCodeForTemplate(String template) {
+    Generator tscfgGenerator = new JavaGen(new GenOpts(packageName, className, false));
+    return tscfgGenerator.generate(ModelBuilder.apply(template).objectType());
+  }
+
+  private Path assembleGeneratedJavaFilePath() {
+    String packageDirectoryPathWithSlash = packageName.replace(PACKAGE_SEPARATOR, File.separator);
+    String javaFileName = className + JAVA_FILE_EXTENSION;
+    return Paths.get(outputDirectory , packageDirectoryPathWithSlash, javaFileName);
+  }
+
+  private void writeGeneratedCodeToJavaFile(String javaClassCode, Path javaClassFile) throws MojoExecutionException {
     try {
-      String outputFilePath = outputDirectory + (outputDirectory.endsWith(File.separator) ? "" : File.separator) +
-          packageName.replace(".", File.separator) + File.separator + className + ".java";
-      Path outputFile = new File(project.getModel().getProjectDirectory(), outputFilePath).toPath();
-
-      getLog().debug("Generating config class to " + outputFile);
-
-      mkDirs(outputFile);
-
-      Files.write(outputFile, result.code().getBytes(UTF_8),
-          StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+      createParentDirsIfNecessary(javaClassFile);
+      Files.write(javaClassFile, javaClassCode.getBytes(UTF_8), StandardOpenOption.CREATE, StandardOpenOption.WRITE);
     } catch (IOException e) {
       throw new MojoExecutionException("Failed to write file: " + e.getClass() + ": " + e.getMessage());
     }
   }
 
-  private void mkDirs(Path outputFile) throws IOException {
+  private void createParentDirsIfNecessary(Path outputFile) throws IOException {
     Path parentDir = outputFile.getParent();
     if (!Files.exists(parentDir)) {
       Files.createDirectories(parentDir);

--- a/maven-plugin/src/main/java/tscfg/TscfgJavaGeneratorMojo.java
+++ b/maven-plugin/src/main/java/tscfg/TscfgJavaGeneratorMojo.java
@@ -64,7 +64,7 @@ public class TscfgJavaGeneratorMojo extends AbstractMojo {
     try {
       return new String(Files.readAllBytes(templateFile.toPath()), UTF_8);
     } catch (IOException e) {
-      throw new MojoExecutionException("Failed to read template file (" + templateFile + "): " + e.getMessage());
+      throw new MojoExecutionException("Failed to read template file (" + templateFile + "): " + e.getClass() + ": " + e.getMessage());
     }
   }
 
@@ -93,23 +93,23 @@ public class TscfgJavaGeneratorMojo extends AbstractMojo {
     }
   }
 
-  public void setTemplateFile(File templateFile) {
+  void setTemplateFile(File templateFile) {
     this.templateFile = templateFile;
   }
 
-  public void setPackageName(String packageName) {
+  void setPackageName(String packageName) {
     this.packageName = packageName;
   }
 
-  public void setClassName(String className) {
+  void setClassName(String className) {
     this.className = className;
   }
 
-  public void setOutputDirectory(String outputDirectory) {
+  void setOutputDirectory(String outputDirectory) {
     this.outputDirectory = outputDirectory;
   }
 
-  public void setProject(MavenProject project) {
+  void setProject(MavenProject project) {
     this.project = project;
   }
 }

--- a/maven-plugin/src/main/java/tscfg/TscfgJavaGeneratorMojo.java
+++ b/maven-plugin/src/main/java/tscfg/TscfgJavaGeneratorMojo.java
@@ -44,18 +44,6 @@ public class TscfgJavaGeneratorMojo extends AbstractMojo {
   @Parameter(defaultValue = "${project}", required = true, readonly = true)
   private MavenProject project;
 
-  public TscfgJavaGeneratorMojo() {
-  }
-
-  // visible for testing
-  protected TscfgJavaGeneratorMojo(File templateFile, String packageName, String className, String outputDirectory, MavenProject project) {
-    this.templateFile = templateFile;
-    this.packageName = packageName;
-    this.className = className;
-    this.outputDirectory = outputDirectory;
-    this.project = project;
-  }
-
   public void execute() throws MojoExecutionException, MojoFailureException {
     String template = readTscfgTemplate();
 

--- a/maven-plugin/src/main/java/tscfg/TscfgJavaGeneratorMojo.java
+++ b/maven-plugin/src/main/java/tscfg/TscfgJavaGeneratorMojo.java
@@ -44,6 +44,18 @@ public class TscfgJavaGeneratorMojo extends AbstractMojo {
   @Parameter(defaultValue = "${project}", required = true, readonly = true)
   private MavenProject project;
 
+  public TscfgJavaGeneratorMojo() {
+  }
+
+  // visible for testing
+  protected TscfgJavaGeneratorMojo(File templateFile, String packageName, String className, String outputDirectory, MavenProject project) {
+    this.templateFile = templateFile;
+    this.packageName = packageName;
+    this.className = className;
+    this.outputDirectory = outputDirectory;
+    this.project = project;
+  }
+
   public void execute() throws MojoExecutionException, MojoFailureException {
     String template = readTscfgTemplate();
 
@@ -70,9 +82,9 @@ public class TscfgJavaGeneratorMojo extends AbstractMojo {
   }
 
   private Path assembleGeneratedJavaFilePath() {
-    String packageDirectoryPathWithSlash = packageName.replace(PACKAGE_SEPARATOR, File.separator);
+    String packageDirectoryPath = packageName.replace(PACKAGE_SEPARATOR, File.separator);
     String javaFileName = className + JAVA_FILE_EXTENSION;
-    return Paths.get(outputDirectory , packageDirectoryPathWithSlash, javaFileName);
+    return Paths.get(outputDirectory, packageDirectoryPath, javaFileName);
   }
 
   private void writeGeneratedCodeToJavaFile(String javaClassCode, Path javaClassFile) throws MojoExecutionException {

--- a/maven-plugin/src/test/java/tscfg/TscfgJavaGeneratorMojoTest.java
+++ b/maven-plugin/src/test/java/tscfg/TscfgJavaGeneratorMojoTest.java
@@ -1,9 +1,11 @@
 package tscfg;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -12,6 +14,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 
 import static java.nio.file.StandardOpenOption.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,6 +29,8 @@ public class TscfgJavaGeneratorMojoTest {
   public TemporaryFolder templateFolder = new TemporaryFolder();
   @Rule
   public TemporaryFolder outputFolder = new TemporaryFolder();
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Mock
   private MavenProject project;
@@ -55,6 +60,29 @@ public class TscfgJavaGeneratorMojoTest {
     String result = new String(Files.readAllBytes(resultFile.toPath()), UTF_8);
     assertThat(result).contains("package com.test.config;");
     assertThat(result).contains("public class TestConfig {");
+  }
+
+  @Test
+  public void executeFullyOverwritesGeneratedFile() throws Exception {
+    mojo.execute();
+
+    File resultFile = new File(outputFolder.getRoot(), "com/test/config/TestConfig.java");
+    Files.write(resultFile.toPath(), "extra".getBytes(UTF_8), StandardOpenOption.APPEND);
+
+    mojo.execute();
+
+    String result = new String(Files.readAllBytes(resultFile.toPath()), UTF_8);
+    assertThat(result).doesNotContain("extra");
+  }
+
+  @Test
+  public void templateFileDoesNotExists() throws Exception {
+    expectedException.expect(MojoExecutionException.class);
+    expectedException.expectMessage("Failed to read template file (");
+    expectedException.expectMessage("unexisting.spec.conf):");
+
+    mojo.setTemplateFile(new File(outputFolder.getRoot(), "unexisting.spec.conf"));
+    mojo.execute();
   }
 
   private byte[] templateContent() {

--- a/maven-plugin/src/test/java/tscfg/TscfgJavaGeneratorMojoTest.java
+++ b/maven-plugin/src/test/java/tscfg/TscfgJavaGeneratorMojoTest.java
@@ -1,0 +1,65 @@
+package tscfg;
+
+import org.apache.maven.project.MavenProject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import static java.nio.file.StandardOpenOption.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static tscfg.TscfgJavaGeneratorMojo.UTF_8;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TscfgJavaGeneratorMojoTest {
+
+  private TscfgJavaGeneratorMojo mojo = new TscfgJavaGeneratorMojo();
+
+  @Rule
+  public TemporaryFolder templateFolder = new TemporaryFolder();
+  @Rule
+  public TemporaryFolder outputFolder = new TemporaryFolder();
+
+  @Mock
+  private MavenProject project;
+
+  @Before
+  public void setUp() throws Exception {
+    mojo.setProject(project);
+
+    File templateFile = templateFolder.newFile("test.spec.conf");
+    Files.write(templateFile.toPath(), templateContent(), CREATE, WRITE, TRUNCATE_EXISTING);
+    mojo.setTemplateFile(templateFile);
+
+    mojo.setOutputDirectory(outputFolder.getRoot().getAbsolutePath());
+    mojo.setClassName("TestConfig");
+    mojo.setPackageName("com.test.config");
+  }
+
+  @Test
+  public void execute() throws Exception {
+    mojo.execute();
+
+    Mockito.verify(project).addCompileSourceRoot(outputFolder.getRoot().getAbsolutePath());
+
+    File resultFile = new File(outputFolder.getRoot(), "com/test/config/TestConfig.java");
+    assertThat(resultFile).exists();
+
+    String result = new String(Files.readAllBytes(resultFile.toPath()), UTF_8);
+    assertThat(result).contains("package com.test.config;");
+    assertThat(result).contains("public class TestConfig {");
+  }
+
+  private byte[] templateContent() {
+    String templateConfig = "test {\n  server: \"string\"\n  port: \"int\"\n}";
+    return templateConfig.getBytes(UTF_8);
+  }
+
+}


### PR DESCRIPTION
This PR contains a maven plugin that generates Typesafe Config using the tscfg tool. 

See README for usage details. Example:
```
            <plugin>
                <groupId>com.github.carueda</groupId>
                <artifactId>tscfg-maven-plugin</artifactId>
                <version>0.2.0</version>
                <configuration>
                    <templateFile>config-spec/app.spec.conf</templateFile>
                    <packageName>be.timvanlaer.service.config</packageName>
                    <className>ApplicationConfig</className>
                </configuration>
                <executions>
                    <execution>
                        <id>tscfg-sources</id>
                        <goals>
                            <goal>generate-config-class</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
```
When you run `mvn generate-sources`, the plugin will read `app.spec.conf` in the `/config-spec` directory at the root of your Maven project. It will generate a Java 8 class `be.timvanlaer.service.config.ApplicationConfig`.