### PR TITLE
Using java.time.Duration and java.utils.Optional

### DIFF
--- a/src/main/java/tscfg/example/JCfg.java
+++ b/src/main/java/tscfg/example/JCfg.java
@@ -1,0 +1,59 @@
+package tscfg.example;
+
+public class JCfg {
+  public final java.lang.Long durHr;
+  public final java.lang.String foo;
+  public final java.lang.String optStr;
+  public final java.util.List<java.util.List<JCfg.Positions$Elm>> positions;
+  public static class Positions$Elm {
+    public final java.util.List<java.lang.Boolean> attrs;
+    public final double lat;
+    public final double lon;
+    
+    public Positions$Elm(com.typesafe.config.Config c) {
+      this.attrs = c.hasPathOrNull("attrs") ? $_L$_bln(c.getList("attrs")) : null;
+      this.lat = c.hasPathOrNull("lat") ? c.getDouble("lat") : 35.1;
+      this.lon = c.getDouble("lon");
+    }
+  }
+  
+  public JCfg(com.typesafe.config.Config c) {
+    this.durHr = c.hasPathOrNull("durHr") ? c.getDuration("durHr", java.util.concurrent.TimeUnit.HOURS) : null;
+    this.foo = c.hasPathOrNull("foo") ? c.getString("foo") : "foo \"val\" etc ";
+    this.optStr = c.hasPathOrNull("optStr") ? c.getString("optStr") : null;
+    this.positions = $_L$_LJCfg_Positions$Elm(c.getList("positions"));
+  }
+  private static java.util.List<java.util.List<JCfg.Positions$Elm>> $_L$_LJCfg_Positions$Elm(com.typesafe.config.ConfigList cl) {
+    java.util.ArrayList<java.util.List<JCfg.Positions$Elm>> al = new java.util.ArrayList<>();
+    for (com.typesafe.config.ConfigValue cv: cl) {
+      al.add($_LJCfg_Positions$Elm((com.typesafe.config.ConfigList)cv));
+    }
+    return java.util.Collections.unmodifiableList(al);
+  }
+  private static java.util.List<JCfg.Positions$Elm> $_LJCfg_Positions$Elm(com.typesafe.config.ConfigList cl) {
+    java.util.ArrayList<JCfg.Positions$Elm> al = new java.util.ArrayList<>();
+    for (com.typesafe.config.ConfigValue cv: cl) {
+      al.add(new JCfg.Positions$Elm(((com.typesafe.config.ConfigObject)cv).toConfig()));
+    }
+    return java.util.Collections.unmodifiableList(al);
+  }
+
+  private static java.util.List<java.lang.Boolean> $_L$_bln(com.typesafe.config.ConfigList cl) {
+    java.util.ArrayList<java.lang.Boolean> al = new java.util.ArrayList<>();
+    for (com.typesafe.config.ConfigValue cv: cl) {
+      al.add($_bln(cv));
+    }
+    return java.util.Collections.unmodifiableList(al);
+  }
+  private static java.lang.Boolean $_bln(com.typesafe.config.ConfigValue cv) {
+    java.lang.Object u = cv.unwrapped();
+    if (cv.valueType() != com.typesafe.config.ConfigValueType.BOOLEAN ||
+      !(u instanceof java.lang.Boolean)) throw $_expE(cv, "boolean");
+    return (java.lang.Boolean) u;
+  }
+  private static java.lang.RuntimeException $_expE(com.typesafe.config.ConfigValue cv, java.lang.String exp) {
+    java.lang.Object u = cv.unwrapped();
+    return new java.lang.RuntimeException(cv.origin().lineNumber()
+      + ": expecting: " +exp + " got: " + (u instanceof java.lang.String ? "\"" +u+ "\"" : u));
+  }
+}

--- a/src/main/scala/tscfg/ModelBuilder.scala
+++ b/src/main/scala/tscfg/ModelBuilder.scala
@@ -3,7 +3,6 @@ package tscfg
 import com.typesafe.config._
 import tscfg.generators.tsConfigUtil
 import tscfg.model.{DURATION, SIZE}
-import tscfg.model.durations.ms
 
 import scala.collection.JavaConverters._
 
@@ -155,7 +154,7 @@ class ModelBuilder {
   Option[(model.BasicType, Boolean, Option[String])] = {
 
     if (tsConfigUtil.isDurationValue(valueString))
-      return Some((DURATION(ms), true, Some(valueString)))
+      return Some((DURATION, true, Some(valueString)))
 
     if (tsConfigUtil.isSizeValue(valueString))
       return Some((SIZE, true, Some(valueString)))
@@ -170,20 +169,7 @@ class ModelBuilder {
     else
       (typePart, hasDefault)
 
-    val (base, qualification) = {
-      val parts = baseString.split("""\s*\:\s*""", 2)
-      if (parts.length == 1)
-        (parts(0), None)
-      else
-        (parts(0), Some(parts(1)))
-    }
-
-    model.recognizedAtomic.get(base) map { bt ⇒
-      val basicType = bt match {
-        case DURATION(_) if qualification.isDefined ⇒
-          DURATION(tsConfigUtil.unifyDuration(qualification.get))
-        case _ ⇒ bt
-      }
+    model.recognizedAtomic.get(baseString) map { basicType ⇒
       (basicType, isOpt, defaultValue)
     }
   }

--- a/src/main/scala/tscfg/generators/JavaGenMain.scala
+++ b/src/main/scala/tscfg/generators/JavaGenMain.scala
@@ -2,7 +2,6 @@ package tscfg.generators
 
 import tscfg.generators.java.JavaGen
 import tscfg.model
-import tscfg.model.durations.hour
 
 object JavaGenMain {
   // $COVERAGE-OFF$
@@ -16,7 +15,7 @@ object JavaGenMain {
         "lon" := DOUBLE,
         "attrs" := ~ListType(BOOLEAN)
       ))),
-      "durHr" := "A duration" % ~DURATION(hour),
+      "durHr" := "A duration" % ~DURATION,
       "foo" := STRING | """foo "val" etc """,
       "optStr" := ~STRING
     )

--- a/src/main/scala/tscfg/generators/ScalaGenMain.scala
+++ b/src/main/scala/tscfg/generators/ScalaGenMain.scala
@@ -2,7 +2,6 @@ package tscfg.generators
 
 import tscfg.generators.scala.ScalaGen
 import tscfg.model
-import tscfg.model.durations.hour
 
 object ScalaGenMain {
   // $COVERAGE-OFF$
@@ -16,7 +15,7 @@ object ScalaGenMain {
         "lon" := DOUBLE,
         "attrs" := ~ListType(BOOLEAN)
       ))),
-      "durHr" := "A duration" % ~DURATION(hour),
+      "durHr" := "A duration" % ~DURATION,
       "foo" := STRING | """foo "val" etc """,
       "optStr" := ~STRING
     )

--- a/src/main/scala/tscfg/generators/scala/ScalaGen.scala
+++ b/src/main/scala/tscfg/generators/scala/ScalaGen.scala
@@ -152,7 +152,7 @@ class ScalaGen(genOpts: GenOpts) extends Generator(genOpts) {
       case DOUBLE   ⇒ "scala.Double"
       case BOOLEAN  ⇒ "scala.Boolean"
       case SIZE     ⇒ "scala.Long"
-      case DURATION(_) ⇒ "scala.Long"
+      case DURATION ⇒ "java.time.Duration"
     }))
   }
 }
@@ -196,8 +196,6 @@ object ScalaGen {
     val generator = new ScalaGen(genOpts)
 
     val results = generator.generate(objectType)
-
-    //println("\n" + results.code)
 
     val destFilename  = s"src/test/scala/tscfg/example/$className.scala"
     val destFile = new File(destFilename)
@@ -371,9 +369,10 @@ private[scala] case class Getter(genOpts: GenOpts, hasPath: String, accessors: A
       case Some(v) ⇒
         val value = tsConfigUtil.basicValue(a.t, v)
         (bt, value) match {
-          case (BOOLEAN, "true")  ⇒ s"""!c.$hasPath("$path") || c.$getter"""
-          case (BOOLEAN, "false") ⇒ s"""c.$hasPath("$path") && c.$getter"""
-          case _                  ⇒ s"""if(c.$hasPath("$path")) c.$getter else $value"""
+          case (BOOLEAN, "true")    ⇒ s"""!c.$hasPath("$path") || c.$getter"""
+          case (BOOLEAN, "false")   ⇒ s"""c.$hasPath("$path") && c.$getter"""
+          case (DURATION, duration) ⇒ s"""if(c.$hasPath("$path")) c.$getter else java.time.Duration.parse("$duration")"""
+          case _                    ⇒ s"""if(c.$hasPath("$path")) c.$getter else $value"""
         }
 
       case None if a.optional ⇒
@@ -442,7 +441,7 @@ private[scala] class Accessors {
     case DOUBLE   ⇒ methodNames.dblA
     case BOOLEAN  ⇒ methodNames.blnA
     case SIZE     ⇒ methodNames.sizA
-    case DURATION(_) ⇒ methodNames.durA
+    case DURATION ⇒ methodNames.durA
 
     case _: ObjectType  ⇒ name.replace('.', '_')
 

--- a/src/main/scala/tscfg/model.scala
+++ b/src/main/scala/tscfg/model.scala
@@ -1,7 +1,5 @@
 package tscfg
 
-import tscfg.model.durations._
-
 object model {
 
   object implicits {
@@ -18,18 +16,6 @@ object model {
     }
   }
 
-  object durations {
-    sealed abstract class DurationQualification
-
-    case object ns      extends DurationQualification
-    case object us      extends DurationQualification
-    case object ms      extends DurationQualification
-    case object second  extends DurationQualification
-    case object minute  extends DurationQualification
-    case object hour    extends DurationQualification
-    case object day     extends DurationQualification
-  }
-
   sealed abstract class Type
 
   sealed abstract class BasicType extends Type
@@ -40,7 +26,7 @@ object model {
   case object DOUBLE    extends BasicType
   case object BOOLEAN   extends BasicType
   case object SIZE      extends BasicType
-  case class DURATION(q: DurationQualification) extends BasicType
+  case object DURATION  extends BasicType
 
   val recognizedAtomic: Map[String, BasicType] = Map(
     "string"    → STRING,
@@ -50,7 +36,7 @@ object model {
     "double"    → DOUBLE,
     "boolean"   → BOOLEAN,
     "size"      → SIZE,
-    "duration"  → DURATION(ms)
+    "duration"  → DURATION
   )
 
   case class ListType(t: Type) extends Type
@@ -135,7 +121,7 @@ object modelMain {
         "lon" := DOUBLE,
         "attrs" := ListType(ObjectType(
           "b" := BOOLEAN,
-          "d" := DURATION(hour)
+          "d" := DURATION
         ))
       )),
       "baz" := "comments for baz..." % ~ObjectType(

--- a/src/main/tscfg/example/duration.spec.conf
+++ b/src/main/tscfg/example/duration.spec.conf
@@ -1,22 +1,16 @@
 durations {
-  # optional duration; reported Long (Option[Long] in scala) is null (None) if value is missing
-  # or whatever is provided converted to days
-  days = "duration:day?"
+  # optional duration; reported java.time.Duration (Option[java.time.Duration] in scala) is Optional.empty() (None) if value is missing
+  # or whatever is provided
+  duration_option = "duration?"
 
-  # required duration; reported long (Long) is whatever is provided
-  # converted to hours
-  hours = "duration:hour"
+  # required duration; reported java.time.Duration is whatever is provided
+  duration = "duration"
 
   # optional duration with default value;
-  # reported long (Long) is in milliseconds, either 550,000 if value is missing
-  # or whatever is provided converted to millis
-  millis = "duration:ms | 550s"
+  # reported java.time.Duration is whatever is provided or 5 days if value is missing
+  duration_default = "duration | 5d"
 
-  duration_ns = "duration : nanos   | 0"
-  duration_µs = "duration : micros  | 0"
-  duration_ms = "duration : ms      | 0"
-  duration_se = "duration : seconds | 0"
-  duration_mi = "duration : minutes | 0"
-  duration_hr = "duration : hour    | 0"
-  duration_dy = "duration : day     | 0"
+  # optional duration with default value;
+  # reported java.time.Duration is whatever is provided or 50 milliseconds if value is missing
+  duration_default_without_Unit = "duration | 50"
 }

--- a/src/test/scala/tscfg/ModelBuilderSpec.scala
+++ b/src/test/scala/tscfg/ModelBuilderSpec.scala
@@ -1,7 +1,6 @@
 package tscfg
 
 import org.specs2.mutable.Specification
-import model.durations._
 import tscfg.buildWarnings.{DefaultListElemWarning, MultElemListWarning, OptListElemWarning}
 import tscfg.model._
 
@@ -151,9 +150,9 @@ class ModelBuilderSpec extends Specification {
         |idleTimeout = 75 seconds
       """.stripMargin)
 
-    "translate into DURATION(ms) with given default" in {
+    "translate into DURATION2 with given default" in {
       val at = result.objectType.members("idleTimeout")
-      at.t === DURATION(ms)
+      at.t === DURATION
       at.optional must beTrue
       at.default must beSome("75 seconds")
     }
@@ -169,13 +168,7 @@ class ModelBuilderSpec extends Specification {
         |  reqDouble     = double
         |  reqBoolean    = boolean
         |  reqDuration   = duration
-        |  duration_ns   = "duration : ns"
-        |  duration_µs   = "duration : us"
-        |  duration_ms   = "duration : ms"
-        |  duration_se   = "duration : s"
-        |  duration_mi   = "duration : m"
-        |  duration_hr   = "duration : h"
-        |  duration_dy   = "duration : d"
+        |  duration      = "duration"
         |  optStr        = "string?"
         |  optInt        = "int?"
         |  optLong       = "long?"
@@ -194,7 +187,7 @@ class ModelBuilderSpec extends Specification {
         |  listDouble    = [ double ]
         |  listBoolean   = [ boolean ]
         |  listDuration  = [ duration ]
-        |  listDuration_se  = [ "duration : second" ]
+        |  listDuration_se  = [ "duration" ]
         |}
       """.stripMargin)
 
@@ -215,13 +208,7 @@ class ModelBuilderSpec extends Specification {
         "reqDouble",
         "reqBoolean",
         "reqDuration",
-        "duration_ns",
-        "duration_µs",
-        "duration_ms",
-        "duration_se",
-        "duration_mi",
-        "duration_hr",
-        "duration_dy",
+        "duration",
         "optStr",
         "optInt",
         "optLong",
@@ -247,33 +234,27 @@ class ModelBuilderSpec extends Specification {
       verify(fooObj, "reqLong",     LONG)
       verify(fooObj, "reqDouble",   DOUBLE)
       verify(fooObj, "reqBoolean",  BOOLEAN)
-      verify(fooObj, "reqDuration", DURATION(ms))
-      verify(fooObj, "duration_ns", DURATION(ns))
-      verify(fooObj, "duration_µs", DURATION(us))
-      verify(fooObj, "duration_ms", DURATION(ms))
-      verify(fooObj, "duration_se", DURATION(second))
-      verify(fooObj, "duration_mi", DURATION(minute))
-      verify(fooObj, "duration_hr", DURATION(hour))
-      verify(fooObj, "duration_dy", DURATION(day ))
+      verify(fooObj, "reqDuration", DURATION)
+      verify(fooObj, "duration", DURATION)
       verify(fooObj, "optStr" ,     STRING,   optional = true)
       verify(fooObj, "optInt" ,     INTEGER,  optional = true)
       verify(fooObj, "optLong",     LONG,     optional = true)
       verify(fooObj, "optDouble",   DOUBLE,   optional = true)
       verify(fooObj, "optBoolean",  BOOLEAN,  optional = true)
-      verify(fooObj, "optDuration", DURATION(ms), optional = true)
+      verify(fooObj, "optDuration", DURATION, optional = true)
       verify(fooObj, "dflStr" ,     STRING,   optional = true, default = Some("hi"))
       verify(fooObj, "dflInt" ,     INTEGER,  optional = true, default = Some("3"))
       verify(fooObj, "dflLong",     LONG,     optional = true, default = Some("999999999"))
       verify(fooObj, "dflDouble",   DOUBLE,   optional = true, default = Some("3.14"))
       verify(fooObj, "dflBoolean",  BOOLEAN,  optional = true, default = Some("false"))
-      verify(fooObj, "dflDuration", DURATION(ms), optional = true, default = Some("21d"))
+      verify(fooObj, "dflDuration", DURATION, optional = true, default = Some("21d"))
       verify(fooObj, "listStr",      ListType(STRING))
       verify(fooObj, "listInt",      ListType(INTEGER))
       verify(fooObj, "listLong",     ListType(LONG))
       verify(fooObj, "listDouble",   ListType(DOUBLE))
       verify(fooObj, "listBoolean",  ListType(BOOLEAN))
-      verify(fooObj, "listDuration", ListType(DURATION(ms)))
-      verify(fooObj, "listDuration_se", ListType(DURATION(second)))
+      verify(fooObj, "listDuration", ListType(DURATION))
+      verify(fooObj, "listDuration_se", ListType(DURATION))
     }
   }
 }

--- a/src/test/scala/tscfg/generators/java/JavaExampleSpec.scala
+++ b/src/test/scala/tscfg/generators/java/JavaExampleSpec.scala
@@ -1,5 +1,7 @@
 package tscfg.generators.java
 
+import java.util.Optional
+
 import com.typesafe.config.ConfigFactory
 import org.specs2.mutable.Specification
 import tscfg.example.JavaExampleCfg
@@ -25,12 +27,12 @@ class JavaExampleSpec extends Specification {
 
     "capture given optional values" in {
       cfg.endpoint.interface_.port must_== 9191
-      cfg.endpoint.interface_.`type` must_== "foo"
+      cfg.endpoint.interface_.`type` must_== Optional.of("foo")
     }
 
     "capture default values" in {
       cfg.endpoint.url must_== "http://example.net"
-      cfg.endpoint.serial must_== null
+      cfg.endpoint.serial must_== Optional.empty()
     }
   }
 

--- a/src/test/scala/tscfg/modelSpec.scala
+++ b/src/test/scala/tscfg/modelSpec.scala
@@ -5,7 +5,6 @@ import org.specs2.mutable.Specification
 class modelSpec extends Specification {
   import model._
   import model.implicits._
-  import model.durations._
 
   "basic ObjectType construction" should {
     val objectType = ObjectType(
@@ -14,7 +13,7 @@ class modelSpec extends Specification {
         "lon" := DOUBLE,
         "attrs" := ListType(ObjectType(
           "b" := BOOLEAN,
-          "d" := DURATION(hour)
+          "d" := DURATION
         ))
       )),
       "baz" := "comments for baz..." % ~ObjectType(


### PR DESCRIPTION
Pull-Request for implementing #37. Using java.time.Duration instead of long, and using java.utils.Optional for optional values in java

