### PR TITLE
Feature/durations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,7 @@ Options (default):
   --java                generate java code               (the default)
   --java:getters        generate getters (see #31)       (false)
   --java:optionals      use Optional instead of null     (false)
+  --durations           use java.time.Duration           (false)
   --tpl <filename>      generate config template         (no default)
   --tpl.ind <string>    template indentation string      ("  ")
   --tpl.cp <string>     prefix for template comments     ("##")
@@ -277,18 +278,21 @@ and an example of use [like this](https://github.com/carueda/tscfg/blob/master/s
 
 The following basic types are supported:
 
-| type in spec  | java type:<br /> req / opt  | scala type:<br /> req / opt
-|---------------|---------------------|--------------------------
-| `string`      | `String`  / `String`    | `String`  / `Option[String]`
-| `int`         | `int`     / `Integer`   | `Int`     / `Option[Int]`
-| `long`        | `long`    / `Long`      | `Long`    / `Option[Long]`
-| `double`      | `double`  / `Double`    | `Double`  / `Option[Double]`
-| `boolean`     | `boolean` / `Boolean`   | `Boolean` / `Option[Boolean]`
-| `size`        | `long`    / `Long`      | `Long`    / `Option[Long]`
-| `duration`    | `long`    / `Long`      | `Long`    / `Option[Long]`
+| type in spec                         | java type:<br /> req / opt  | scala type:<br /> req / opt
+|--------------------------------------|--------------------------|---------------------------------
+| `string`                             | `String`   / `String`    | `String`   / `Option[String]`
+| `int`                                | `int`      / `Integer`   | `Int`      / `Option[Int]`
+| `long`                               | `long`     / `Long`      | `Long`     / `Option[Long]`
+| `double`                             | `double`   / `Double`    | `Double`   / `Option[Double]`
+| `boolean`                            | `boolean`  / `Boolean`   | `Boolean`  / `Option[Boolean]`
+| `size`                               | `long`     / `Long`      | `Long`     / `Option[Long]`
+| `duration`                           | `long`     / `Long`      | `Long`     / `Option[Long]`
+| `duration` (using `--duration` flag) | `Duration` / `Duration`  | `Duration` / `Option[Duration]`
 
-> Note: please read `Optional<T>` instead of the `T` values in the
-java "opt" column above if using the `--java:optionals` flag.
+> **NOTE**
+> - please read `Optional<T>` instead of the `T` values in the
+    java "opt" column above if using the `--java:optionals` flag.
+> - using the `--duration` flag, `java.time.Duration` is used instead of `long` / `Long`. See [durations](#durations) for further information. 
 
 
 #### size-in-bytes
@@ -328,6 +332,9 @@ durations {
   ...
 }
 ```
+Using the `--duration` flag, the reported value will be a `java.time.Duration` instead of a `long` / `Long` and the suffix will be ignored:
+`"duration:hours | 3day"` is `java.time.Duration.ofDays(3)` if value is missing or whatever is provided converted to a `java.time.Duration` 
+
 
 ### list type
 

--- a/src/main/scala/tscfg/Main.scala
+++ b/src/main/scala/tscfg/Main.scala
@@ -39,6 +39,7 @@ object Main {
        |  --java                generate java code               (the default)
        |  --java:getters        generate getters (see #31)       (false)
        |  --java:optionals      use optionals                    (false)
+       |  --durations           use java.time.Duration           (false)
        |  --tpl <filename>      generate config template         (no default)
        |  --tpl.ind <string>    template indentation string      ("${templateOpts.indent}")
        |  --tpl.cp <string>     prefix for template comments     ("${templateOpts.commentPrefix}")
@@ -57,6 +58,7 @@ object Main {
                          useBackticks: Boolean = false,
                          genGetters: Boolean = false,
                          useOptionals: Boolean = false,
+                         useDurations: Boolean = false,
                          tplFilename: Option[String] = None
                         )
 
@@ -111,6 +113,9 @@ object Main {
         case "--java:optionals" ::rest =>
           traverseList(rest, opts.copy(useOptionals = true))
 
+        case "--durations" :: rest =>
+          traverseList(rest, opts.copy(useDurations = true))
+
         case "--tpl" :: filename :: rest =>
           traverseList(rest, opts.copy(tplFilename = Some(filename)))
 
@@ -153,7 +158,8 @@ object Main {
                           reportFullPath = opts.reportFullPath,
                           useBackticks = opts.useBackticks,
                           genGetters = opts.genGetters,
-                          useOptionals = opts.useOptionals)
+                          useOptionals = opts.useOptionals,
+                          useDurations = opts.useDurations)
 
     println(s"parsing: $inputFilename")
     val source = io.Source.fromFile(new File(inputFilename)).mkString.trim

--- a/src/main/scala/tscfg/gen4tests.scala
+++ b/src/main/scala/tscfg/gen4tests.scala
@@ -33,6 +33,7 @@ object gen4tests {
         case "--scala:bt"      ⇒ genOpts = genOpts.copy(useBackticks = true)
         case "--java:getters"  ⇒ genOpts = genOpts.copy(genGetters = true)
         case "--java:optionals"  ⇒ genOpts = genOpts.copy(useOptionals = true)
+        case "--durations"     ⇒ genOpts = genOpts.copy(useDurations = true)
 
         // $COVERAGE-OFF$
         case opt ⇒ println(s"WARN: $confFile: unrecognized GenOpts argument: `$opt'")

--- a/src/main/scala/tscfg/generators/Generator.scala
+++ b/src/main/scala/tscfg/generators/Generator.scala
@@ -29,7 +29,8 @@ case class GenOpts(packageName: String,
                    reportFullPath: Boolean = false,
                    useBackticks: Boolean = false,
                    genGetters: Boolean = false,
-                   useOptionals: Boolean = false
+                   useOptionals: Boolean = false,
+                   useDurations: Boolean = false
                   )
 
 case class GenResult(code: String = "?",

--- a/src/main/scala/tscfg/generators/tsConfigUtil.scala
+++ b/src/main/scala/tscfg/generators/tsConfigUtil.scala
@@ -80,19 +80,6 @@ object tsConfigUtil {
       case `day`    =>  "DAYS"
     })
 
-  def temporalUnitString(q: DurationQualification): String = {
-    "java.time.temporal.ChronoUnit." + (q match {
-      case `ns`     => "NANOS"
-      case `us`     => "MICROS"
-      case `ms`     => "MILLIS"
-      case `second` => "SECONDS"
-      case `minute` => "MINUTES"
-      case `hour`   => "HOURS"
-      case `day`    => "DAYS"
-    })
-  }
-
-
   private def timeUnitParam(q: DurationQualification): TimeUnit = q match {
     case `ns`     =>  TimeUnit.NANOSECONDS
     case `us`     =>  TimeUnit.MICROSECONDS

--- a/src/main/tscfg/example/duration2.spec.conf
+++ b/src/main/tscfg/example/duration2.spec.conf
@@ -1,0 +1,23 @@
+// GenOpts: --durations
+durations {
+  # optional duration; reported Long (Option[Long] in scala) is null (None) if value is missing
+  # or whatever is provided converted to days
+  days = "duration:day?"
+
+  # required duration; reported long (Long) is whatever is provided
+  # converted to hours
+  hours = "duration:hour"
+
+  # optional duration with default value;
+  # reported long (Long) is in milliseconds, either 550,000 if value is missing
+  # or whatever is provided converted to millis
+  millis = "duration:ms | 550s"
+
+  duration_ns = "duration : nanos   | 0"
+  duration_µs = "duration : micros  | 0"
+  duration_ms = "duration : ms      | 0"
+  duration_se = "duration : seconds | 0"
+  duration_mi = "duration : minutes | 0"
+  duration_hr = "duration : hour    | 0"
+  duration_dy = "duration : day     | 0"
+}

--- a/src/main/tscfg/example/duration3.spec.conf
+++ b/src/main/tscfg/example/duration3.spec.conf
@@ -1,0 +1,23 @@
+// GenOpts: --durations --java:getters
+durations {
+  # optional duration; reported Long (Option[Long] in scala) is null (None) if value is missing
+  # or whatever is provided converted to days
+  days = "duration:day?"
+
+  # required duration; reported long (Long) is whatever is provided
+  # converted to hours
+  hours = "duration:hour"
+
+  # optional duration with default value;
+  # reported long (Long) is in milliseconds, either 550,000 if value is missing
+  # or whatever is provided converted to millis
+  millis = "duration:ms | 550s"
+
+  duration_ns = "duration : nanos   | 0"
+  duration_µs = "duration : micros  | 0"
+  duration_ms = "duration : ms      | 0"
+  duration_se = "duration : seconds | 0"
+  duration_mi = "duration : minutes | 0"
+  duration_hr = "duration : hour    | 0"
+  duration_dy = "duration : day     | 0"
+}

--- a/src/test/scala/tscfg/generators/java/JavaMainSpec.scala
+++ b/src/test/scala/tscfg/generators/java/JavaMainSpec.scala
@@ -1,6 +1,9 @@
 package tscfg.generators.java
 
 import java.util.Optional
+import java.time.Duration
+import java.time.temporal.ChronoUnit.MICROS
+
 import com.typesafe.config.ConfigFactory
 import org.specs2.mutable.Specification
 import tscfg.example._
@@ -296,6 +299,94 @@ class JavaMainSpec extends Specification {
       c.durations.duration_mi === 7
       c.durations.duration_hr === 7
       c.durations.duration_dy === 7
+    }
+  }
+
+  "duration2" should {
+    "generate code" in {
+      val r = JavaGen.generate("example/duration2.spec.conf", useDurations = true)
+      r.classNames === Set("JavaDuration2Cfg", "Durations")
+      r.fields.keySet === Set("durations", "days", "hours", "millis",
+        "duration_ns",
+        "duration_µs",
+        "duration_ms",
+        "duration_se",
+        "duration_mi",
+        "duration_hr",
+        "duration_dy"
+      )
+    }
+
+    "example 1" in {
+      val c = new JavaDuration2Cfg(ConfigFactory.parseString(
+        """
+          |durations {
+          |  days  = "10d"
+          |  hours = "24h"
+          |  duration_ns = "7ns"
+          |  duration_µs = "7us"
+          |  duration_ms = "7ms"
+          |  duration_se = "7s"
+          |  duration_mi = "7m"
+          |  duration_hr = "7h"
+          |  duration_dy = "7d"
+          |}
+          |""".stripMargin
+      ))
+      c.durations.days === Duration.ofDays(10)
+      c.durations.hours === Duration.ofHours(24)
+      c.durations.millis === Duration.ofMillis(550000)
+      c.durations.duration_ns === Duration.ofNanos(7)
+      c.durations.duration_µs === Duration.of(7, MICROS)
+      c.durations.duration_ms === Duration.ofMillis(7)
+      c.durations.duration_se === Duration.ofSeconds(7)
+      c.durations.duration_mi === Duration.ofMinutes(7)
+      c.durations.duration_hr === Duration.ofHours(7)
+      c.durations.duration_dy === Duration.ofDays(7)
+    }
+  }
+
+  "duration3" should {
+    "generate code" in {
+      val r = JavaGen.generate("example/duration3.spec.conf", useDurations = true, genGetters = true)
+      r.classNames === Set("JavaDuration3Cfg", "Durations")
+      r.fields.keySet === Set("durations", "days", "hours", "millis",
+        "duration_ns",
+        "duration_µs",
+        "duration_ms",
+        "duration_se",
+        "duration_mi",
+        "duration_hr",
+        "duration_dy"
+      )
+    }
+
+    "example 1" in {
+      val c = new JavaDuration3Cfg(ConfigFactory.parseString(
+        """
+          |durations {
+          |  days  = "10d"
+          |  hours = "24h"
+          |  duration_ns = "7ns"
+          |  duration_µs = "7us"
+          |  duration_ms = "7ms"
+          |  duration_se = "7s"
+          |  duration_mi = "7m"
+          |  duration_hr = "7h"
+          |  duration_dy = "7d"
+          |}
+          |""".stripMargin
+      ))
+      c.durations.getDays === Duration.ofDays(10)
+      c.durations.getHours === Duration.ofHours(24)
+      c.durations.getMillis === Duration.ofMillis(550000)
+      c.durations.getDuration_ns === Duration.ofNanos(7)
+      c.durations.getDuration_µs === Duration.of(7, MICROS)
+      c.durations.getDuration_ms === Duration.ofMillis(7)
+      c.durations.getDuration_se === Duration.ofSeconds(7)
+      c.durations.getDuration_mi === Duration.ofMinutes(7)
+      c.durations.getDuration_hr === Duration.ofHours(7)
+      c.durations.getDuration_dy === Duration.ofDays(7)
     }
   }
 

--- a/src/test/scala/tscfg/generators/scala/ScalaMainSpec.scala
+++ b/src/test/scala/tscfg/generators/scala/ScalaMainSpec.scala
@@ -1,5 +1,8 @@
 package tscfg.generators.scala
 
+import java.time.Duration
+import java.time.temporal.ChronoUnit.MICROS
+
 import com.typesafe.config.ConfigFactory
 import org.specs2.mutable.Specification
 import tscfg.example.{ScalaDurationCfg, _}
@@ -7,6 +10,7 @@ import tscfg.generators.GenOpts
 import tscfg.model
 import tscfg.model._
 import model.implicits._
+import tscfg.generators.java.JavaGen
 
 
 class ScalaMainSpec extends Specification {
@@ -301,6 +305,51 @@ class ScalaMainSpec extends Specification {
       )
     }
   }
+
+  "duration2" should {
+    "generate code" in {
+      val r = JavaGen.generate("example/duration2.spec.conf", useDurations = true)
+      r.classNames === Set("JavaDuration2Cfg", "Durations")
+      r.fields.keySet === Set("durations", "days", "hours", "millis",
+        "duration_ns",
+        "duration_µs",
+        "duration_ms",
+        "duration_se",
+        "duration_mi",
+        "duration_hr",
+        "duration_dy"
+      )
+    }
+
+    "example 1" in {
+      val c = ScalaDuration2Cfg(ConfigFactory.parseString(
+        """
+          |durations {
+          |  days  = "10d"
+          |  hours = "24h"
+          |  duration_ns = "7ns"
+          |  duration_µs = "7us"
+          |  duration_ms = "7ms"
+          |  duration_se = "7s"
+          |  duration_mi = "7m"
+          |  duration_hr = "7h"
+          |  duration_dy = "7d"
+          |}
+          |""".stripMargin
+      ))
+      c.durations.days === Some(Duration.ofDays(10))
+      c.durations.hours === Duration.ofHours(24)
+      c.durations.millis === Duration.ofMillis(550000)
+      c.durations.duration_ns === Duration.ofNanos(7)
+      c.durations.duration_µs === Duration.of(7, MICROS)
+      c.durations.duration_ms === Duration.ofMillis(7)
+      c.durations.duration_se === Duration.ofSeconds(7)
+      c.durations.duration_mi === Duration.ofMinutes(7)
+      c.durations.duration_hr === Duration.ofHours(7)
+      c.durations.duration_dy === Duration.ofDays(7)
+    }
+  }
+
 
   "issue19" should {
     """put underscores for key having $""" in {


### PR DESCRIPTION
Added a feature flag `--duration`, for using `java.time.Duration` instead of `long` for Duration fields.